### PR TITLE
feat(devopsarr/prowlarr-py#11): add request timeout to config

### DIFF
--- a/templates/py/api_client.mustache
+++ b/templates/py/api_client.mustache
@@ -201,6 +201,10 @@ class ApiClient(object):
             resource_path, method, body,
             request_auth=_request_auth)
 
+        # request timeout
+        if not _request_timeout:
+            _request_timeout = config.request_timeout
+
         # body
         if body:
             body = self.sanitize_for_serialization(body)

--- a/templates/py/configuration.mustache
+++ b/templates/py/configuration.mustache
@@ -62,6 +62,7 @@ class Configuration(object):
       disabled. This can be useful to troubleshoot data validation problem, such as
       when the OpenAPI document validation rules do not match the actual API data
       received by the server.
+    :param request_timeout: Default request timeout.
 {{#hasHttpSignatureMethods}}
     :param signing_info: Configuration parameters for the HTTP signature security scheme.
         Must be an instance of {{{packageName}}}.signing.HttpSigningConfiguration
@@ -170,6 +171,7 @@ conf = {{{packageName}}}.Configuration(
                  username=None, password=None,
                  discard_unknown_keys=False,
                  disabled_client_side_validations="",
+                 request_timeout=None,
 {{#hasHttpSignatureMethods}}
                  signing_info=None,
 {{/hasHttpSignatureMethods}}
@@ -215,6 +217,9 @@ conf = {{{packageName}}}.Configuration(
         """
         self.discard_unknown_keys = discard_unknown_keys
         self.disabled_client_side_validations = disabled_client_side_validations
+        self.request_timeout = request_timeout
+        """Request Timeout
+        """
 {{#hasHttpSignatureMethods}}
         if signing_info is not None:
             signing_info.host = host


### PR DESCRIPTION
This is to add `request_timeout` parameter in the `Configuration` object.
By default it will be `None`, and `_request_timeout` of any API method will take precedence over this value.